### PR TITLE
Persist and display test and agent configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
   testImplementation("org.jooq:joox:1.6.2")
   testImplementation("com.jayway.jsonpath:json-path:2.6.0")
+  testImplementation("com.google.code.gson:gson:2.8.9")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
 }
 

--- a/src/test/java/io/opentelemetry/agents/Agent.java
+++ b/src/test/java/io/opentelemetry/agents/Agent.java
@@ -20,7 +20,7 @@ public class Agent {
 
   public final static Agent SPLUNK_OTEL = new Agent("splunk-otel", "splunk-otel-java 1.7.1",
           SPLUNK_AGENT_URL);
-  public final static Agent SPLUNK_PROFILER = new Agent("profiler", "splunk-otel-java 1.7.1",
+  public final static Agent SPLUNK_PROFILER = new Agent("profiler", "splunk-otel-java 1.7.1 w/ profiler",
           SPLUNK_AGENT_URL,
           List.of("-Dsplunk.profiler.enabled=true"));
   public final static Agent SPLUNK_PROFILER_W_TLAB_1SS = new Agent("profiler-tlab-1ss", "splunk-otel-java 1.6.0",

--- a/src/test/java/io/opentelemetry/results/ConfigPersister.java
+++ b/src/test/java/io/opentelemetry/results/ConfigPersister.java
@@ -1,0 +1,30 @@
+package io.opentelemetry.results;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.opentelemetry.config.TestConfig;
+
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+public class ConfigPersister {
+
+    private final Path outfile;
+
+    public ConfigPersister(Path outfile) {
+        this.outfile = outfile;
+    }
+
+    public void write(TestConfig config) {
+        Gson gson = new GsonBuilder()
+                .setPrettyPrinting()
+                .create();
+        String json = gson.toJson(config);
+        try (PrintStream out = new PrintStream(outfile.toFile())){
+            out.print(json);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException("Error opening output json config file: " + outfile, e);
+        }
+    }
+}

--- a/src/test/java/io/opentelemetry/results/MainResultsPersister.java
+++ b/src/test/java/io/opentelemetry/results/MainResultsPersister.java
@@ -27,6 +27,7 @@ public class MainResultsPersister implements ResultsPersister {
     new ConsoleResultsPersister().write(results);
     new FileSummaryPersister(outputDir.resolve("summary.txt")).write(results);
     new CsvPersister(outputDir.resolve("results.csv")).write(results);
+    new ConfigPersister(outputDir.resolve("config.json")).write(config);
   }
 
   private void ensureCreated(Path outputDir) {

--- a/web/data-client.js
+++ b/web/data-client.js
@@ -17,3 +17,13 @@ async function getResults(name){
             return aggregated;
         });
 }
+
+async function getConfig(name){
+    const path = `results/${name}/config.json`;
+    return fetch(path)
+        .then(resp => resp.json())
+        .catch(e => {
+            console.log(`No such config found for ${path}`)
+            return {};
+    });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -70,23 +70,6 @@
                 <a id="a-overview"></a>
                 <h2>Config/Overview</h2>
                 <div class="mx-3" id="overview">
-                    <h4>release_30vu_8500iter</h4>
-                    <p class='my-3'>multiple agent configurations compared</p>
-                    <ul>
-                        <li>concurrent connections: 30</li>
-                        <li>max rate: 900 rps</li>
-                        <li>script iterations: 8500</li>
-                        <li>warmup: 60s</li>
-                    </ul>
-                    <div class="card" style="width: 18rem;">
-                        <div class="card-body">
-                            <h5 class="card-title">Splunk Java OTel agent (splunk-otel)</h5>
-                            <h6 class="card-subtitle mb-2 text-muted">splunk-otel-java 1.7.1</h6>
-                            <p class="card-text">-Dsplunk.profiler.enabled=true"</p>
-                            <a href="#" class="card-link">Card link</a>
-                            <a href="#" class="card-link">Another link</a>
-                        </div>
-                    </div>
                 </div>
             </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,7 @@
     <script src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/chartist-plugin-axistitle@0.0.7/dist/chartist-plugin-axistitle.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/chartist-plugin-barlabels@0.0.5/dist/chartist-plugin-barlabels.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="overhead.css">
     <script src="data-client.js"></script>
     <script src="data-util.js"></script>
@@ -39,6 +40,7 @@
         <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
             <div class="position-sticky pt-5">
                 <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link link-dark" href="#a-overview">Config/Overview</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-startup">Startup Time</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-avgcpu">Average CPU (user)</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-maxcpu">Max CPU (user)</a></li>
@@ -64,6 +66,30 @@
             </div>
         </nav>
         <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="container-fluid">
+                <a id="a-overview"></a>
+                <h2>Config/Overview</h2>
+                <div class="mx-3" id="overview">
+                    <h4>release_30vu_8500iter</h4>
+                    <p class='my-3'>multiple agent configurations compared</p>
+                    <ul>
+                        <li>concurrent connections: 30</li>
+                        <li>max rate: 900 rps</li>
+                        <li>script iterations: 8500</li>
+                        <li>warmup: 60s</li>
+                    </ul>
+                    <div class="card" style="width: 18rem;">
+                        <div class="card-body">
+                            <h5 class="card-title">Splunk Java OTel agent (splunk-otel)</h5>
+                            <h6 class="card-subtitle mb-2 text-muted">splunk-otel-java 1.7.1</h6>
+                            <p class="card-text">-Dsplunk.profiler.enabled=true"</p>
+                            <a href="#" class="card-link">Card link</a>
+                            <a href="#" class="card-link">Another link</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="container-fluid">
                 <a id="a-startup"></a>
                 <h2 class="mx-5 px-5">Startup time</h2>

--- a/web/overhead.css
+++ b/web/overhead.css
@@ -1,3 +1,5 @@
+@import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css");
+
 body {
     padding: 0;
     margin: 0;
@@ -21,6 +23,10 @@ h2:before {
     height: 110px;
     content: "";
     display:block;
+}
+
+.jvmarg {
+    font-size: .7em;
 }
 
 .ct-bar {


### PR DESCRIPTION
Along with the test results, we now create an artifact of the test configuration at the time. It is then rendered as "overview" in the UI, and looks something like this:

<img width="856" alt="image" src="https://user-images.githubusercontent.com/75337021/153517683-31dd8891-fe97-4c24-9e76-de9b346ed6b0.png">

The little icons are links to the agent jars. 🤷🏻 
Probably room for improvement here, but at least it takes the question out of what version was used when.