### PR TITLE
Add averaged yaml summary persister

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   testImplementation("org.jooq:joox:1.6.2")
   testImplementation("com.jayway.jsonpath:json-path:2.6.0")
   testImplementation("com.google.code.gson:gson:2.8.9")
+  testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
 }
 

--- a/provision/create-results-pr.sh
+++ b/provision/create-results-pr.sh
@@ -43,8 +43,11 @@ rsync -avv --progress "${RESULTS}/${REV}" github-clone/results/
 cd github-clone
 echo "Results list: " && ls -l results/
 ls -1 results/ | grep -v README | grep -v index.txt > results/index.txt
+echo "Copying latest yaml..."
+cp results/${REV}/results.yaml results/latest.yaml
 echo "Adding new files to changelist"
 git add results/index.txt
+git add results/latest.yaml
 git add results/${REV}/*
 echo "Committing changes..."
 git commit -S -am "Add test results: ${REV}"

--- a/src/test/java/io/opentelemetry/results/CsvToResults.java
+++ b/src/test/java/io/opentelemetry/results/CsvToResults.java
@@ -1,0 +1,123 @@
+package io.opentelemetry.results;
+
+import io.opentelemetry.agents.Agent;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.lang.Double.parseDouble;
+import static java.lang.Float.parseFloat;
+import static java.lang.Long.parseLong;
+
+// Can be used for ad-hoc testing to recreate results without running slow tests
+class CsvToResults {
+
+    static List<AppPerfResults> read(String pathToFile) throws Exception {
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(new BufferedInputStream(new FileInputStream(pathToFile))));
+        String first = in.readLine();
+        List<Field> fields = readFields(first);
+
+        List<AppPerfResults> result = new ArrayList<>();
+        while (true) {
+            String line = in.readLine();
+            if (line == null) break;
+            List<String> lineFields = Arrays.asList(line.split(","));
+            lineFields = lineFields.subList(1, lineFields.size());
+            result.addAll(buildResults(fields, lineFields));
+        }
+
+        return result;
+    }
+
+    private static List<AppPerfResults> buildResults(List<Field> fields, List<String> lineFields) {
+        Map<String, Map<String, String>> agentToFieldValues = new HashMap<>();
+        fields.stream()
+                .map(f -> f.agent)
+                .distinct()
+                .forEach(agent -> agentToFieldValues.put(agent, new HashMap<>()));
+        for (int i = 0; i < fields.size(); i++) {
+            Field field = fields.get(i);
+            agentToFieldValues.get(field.agent).put(field.field, lineFields.get(i));
+        }
+        return agentToFieldValues.entrySet().stream().map(entry -> {
+                    Map<String, String> fieldValues = entry.getValue();
+                    fieldValues.put("agent", entry.getKey());   // throw agent in there for later
+                    return fieldValues;
+                })
+                .map(CsvToResults::toAppPerfResults)
+                .collect(Collectors.toList());
+    }
+
+    private static AppPerfResults toAppPerfResults(Map<String, String> fv) {
+        AppPerfResults.MinMax heap = new AppPerfResults.MinMax(parseLong(fv.get("minHeapUsed")), parseLong(fv.get("maxHeapUsed")));
+        Agent agent = findAgent(fv.get("agent"));
+        return AppPerfResults.builder()
+                .agent(agent)
+                .startupDurationMs(parseLong(fv.get("startupDurationMs")))
+                .heapUsed(heap)
+                .totalAllocated((long)parseDouble(fv.get("totalAllocatedMB"))*1024*1024)
+                .totalGCTime(parseLong(fv.get("totalGCTime")))
+                .maxThreadContextSwitchRate(parseFloat(fv.get("maxThreadContextSwitchRate")))
+                .iterationAvg(parseDouble(fv.get("iterationAvg")))
+                .iterationP95(parseDouble(fv.get("iterationP95")))
+                .requestAvg(parseDouble(fv.get("requestAvg")))
+                .requestP95(parseDouble(fv.get("requestP95")))
+                .averageNetworkRead(parseLong(fv.get("netReadAvg")))
+                .averageNetworkWrite(parseLong(fv.get("netWriteAvg")))
+                .peakThreadCount(parseLong(fv.get("peakThreadCount")))
+                .averageJvmUserCpu(parseFloat(fv.get("averageCpuUser")))
+                .maxJvmUserCpu(parseFloat(fv.get("maxCpuUser")))
+                .averageJvmSystemCpu(parseFloat(fv.get("averageCpuSystem")))
+                .maxJvmSystemCpu(parseFloat(fv.get("maxCpuSystem")))
+                .averageMachineCpuTotal(parseFloat(fv.get("averageMachineCpuTotal")))
+                .runDurationMs(parseLong(fv.get("runDurationMs")))
+                .totalGcPauseNanos(TimeUnit.MILLISECONDS.toNanos(parseLong(fv.get("gcPauseMs"))))
+                .throughputRequestsPerSecond(parseDouble(fv.get("throughputAvg")))
+                .build();
+    }
+
+    private static Agent findAgent(String agent) {
+        switch(agent){
+            case "none":
+                return Agent.NONE;
+            case "splunk-otel":
+                return Agent.SPLUNK_OTEL;
+            case "splunk-otel-profiler":
+            case "profiler":
+                return Agent.SPLUNK_PROFILER;
+        }
+        return new Agent("unknown", "unknown agent");
+    }
+
+    private static List<Field> readFields(String firstLine) {
+        String[] firstFields = firstLine.split(",");
+        return Arrays.stream(firstFields)
+                .skip(1)
+                .map(field -> {
+                    String[] parts = field.split(":");
+                    return new Field(parts[0], parts[1]);
+                }).collect(Collectors.toList());
+    }
+
+    static class Field {
+        String agent;
+        String field;
+
+        public Field(String agent, String field) {
+            this.agent = agent;
+            this.field = field;
+        }
+    }
+
+
+}

--- a/src/test/java/io/opentelemetry/results/MainResultsPersister.java
+++ b/src/test/java/io/opentelemetry/results/MainResultsPersister.java
@@ -26,6 +26,7 @@ public class MainResultsPersister implements ResultsPersister {
     ensureCreated(outputDir);
     new ConsoleResultsPersister().write(results);
     new FileSummaryPersister(outputDir.resolve("summary.txt")).write(results);
+    new YamlSummaryPersister(outputDir.resolve("results.yaml")).write(results);
     new CsvPersister(outputDir.resolve("results.csv")).write(results);
     new ConfigPersister(outputDir.resolve("config.json")).write(config);
   }

--- a/src/test/java/io/opentelemetry/results/ResultsAverager.java
+++ b/src/test/java/io/opentelemetry/results/ResultsAverager.java
@@ -1,0 +1,76 @@
+package io.opentelemetry.results;
+
+import org.testcontainers.shaded.com.google.common.base.Function;
+import org.testcontainers.shaded.com.google.common.collect.Maps;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ResultsAverager {
+
+    private final List<AppPerfResults> rawResults;
+
+    public ResultsAverager(List<AppPerfResults> rawResults) {
+        this.rawResults = rawResults;
+    }
+
+    public Map<String,AppPerfResults> average(List<AppPerfResults> rawResults){
+        Map<String, List<AppPerfResults>> groupedByAgent = rawResults.stream()
+                .reduce(new HashMap<>(),
+                        (map, res) -> {
+                            List<AppPerfResults> list = map.computeIfAbsent(res.getAgentName(), k -> new ArrayList<>());
+                            list.add(res);
+                            return map;
+                        }, (stringListHashMap, stringListHashMap2) -> {
+                            stringListHashMap.putAll(stringListHashMap2);
+                            return stringListHashMap;
+                        });
+        return Maps.transformValues(groupedByAgent, this::combine);
+    }
+
+    private AppPerfResults combine(List<AppPerfResults> results){
+        long minHeap = avgLong(results, r -> r.heapUsed.min);
+        long maxHeap = avgLong(results, r -> r.heapUsed.max);
+        AppPerfResults.MinMax heap = new AppPerfResults.MinMax(minHeap, maxHeap);
+        return AppPerfResults.builder()
+                .agent(results.get(0).agent)
+                .startupDurationMs(avgLong(results, x -> x.startupDurationMs))
+                .heapUsed(heap)
+                .totalAllocated(avgLong(results, x -> x.totalAllocated))
+                .totalGCTime(avgLong(results, x -> x.totalGCTime))
+                .maxThreadContextSwitchRate(avgFloat(results, x -> x.maxThreadContextSwitchRate))
+                .iterationAvg(avgDouble(results, x -> x.iterationAvg))
+                .iterationP95(avgDouble(results, x -> x.iterationP95))
+                .requestAvg(avgDouble(results, x -> x.requestAvg))
+                .requestP95(avgDouble(results, x -> x.requestP95))
+                .averageNetworkRead(avgLong(results, x -> x.averageNetworkRead))
+                .averageNetworkWrite(avgLong(results, x -> x.averageNetworkWrite))
+                .peakThreadCount(avgLong(results, x -> x.peakThreadCount))
+                .averageJvmUserCpu(avgFloat(results, x -> x.maxJvmUserCpu))
+                .maxJvmUserCpu(avgFloat(results, x -> x.maxJvmUserCpu))
+                .averageJvmSystemCpu(avgFloat(results, x -> x.averageJvmSystemCpu))
+                .maxJvmSystemCpu(avgFloat(results, x -> x.maxJvmSystemCpu))
+                .averageMachineCpuTotal(avgFloat(results, x -> x.averageMachineCpuTotal))
+                .runDurationMs(avgLong(results, x -> x.runDurationMs))
+                .totalGcPauseNanos(avgLong(results, x -> x.totalGcPauseNanos))
+                .throughputRequestsPerSecond(avgDouble(results, x -> x.throughputRequestsPerSecond))
+                .build();
+    }
+
+    private float avgFloat(List<AppPerfResults> results, Function<AppPerfResults,Float> fn){
+        float sum = results.stream().reduce(0.0f, (acc, cur) -> acc + fn.apply(cur), Float::sum);
+        return sum/results.size();
+    }
+
+    private double avgDouble(List<AppPerfResults> results, Function<AppPerfResults,Double> fn){
+        double sum = results.stream().reduce(0.0, (acc, cur) -> acc + fn.apply(cur), Double::sum);
+        return sum/results.size();
+    }
+
+    private long avgLong(List<AppPerfResults> results, Function<AppPerfResults,Long> fn){
+        long sum = results.stream().reduce(0L, (acc, cur) -> acc + fn.apply(cur), Long::sum);
+        return sum/results.size();
+    }
+}

--- a/src/test/java/io/opentelemetry/results/ResultsAverager.java
+++ b/src/test/java/io/opentelemetry/results/ResultsAverager.java
@@ -1,12 +1,9 @@
 package io.opentelemetry.results;
 
-import org.testcontainers.shaded.com.google.common.base.Function;
-import org.testcontainers.shaded.com.google.common.collect.Maps;
-
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 public class ResultsAverager {
 
@@ -16,61 +13,38 @@ public class ResultsAverager {
         this.rawResults = rawResults;
     }
 
-    public Map<String,AppPerfResults> average(List<AppPerfResults> rawResults){
-        Map<String, List<AppPerfResults>> groupedByAgent = rawResults.stream()
-                .reduce(new HashMap<>(),
-                        (map, res) -> {
-                            List<AppPerfResults> list = map.computeIfAbsent(res.getAgentName(), k -> new ArrayList<>());
-                            list.add(res);
-                            return map;
-                        }, (stringListHashMap, stringListHashMap2) -> {
-                            stringListHashMap.putAll(stringListHashMap2);
-                            return stringListHashMap;
-                        });
-        return Maps.transformValues(groupedByAgent, this::combine);
+    double jvmUserCpu(String agentName){
+        return avgDouble(agentName, x -> (double)x.averageJvmUserCpu);
     }
 
-    private AppPerfResults combine(List<AppPerfResults> results){
-        long minHeap = avgLong(results, r -> r.heapUsed.min);
-        long maxHeap = avgLong(results, r -> r.heapUsed.max);
-        AppPerfResults.MinMax heap = new AppPerfResults.MinMax(minHeap, maxHeap);
-        return AppPerfResults.builder()
-                .agent(results.get(0).agent)
-                .startupDurationMs(avgLong(results, x -> x.startupDurationMs))
-                .heapUsed(heap)
-                .totalAllocated(avgLong(results, x -> x.totalAllocated))
-                .totalGCTime(avgLong(results, x -> x.totalGCTime))
-                .maxThreadContextSwitchRate(avgFloat(results, x -> x.maxThreadContextSwitchRate))
-                .iterationAvg(avgDouble(results, x -> x.iterationAvg))
-                .iterationP95(avgDouble(results, x -> x.iterationP95))
-                .requestAvg(avgDouble(results, x -> x.requestAvg))
-                .requestP95(avgDouble(results, x -> x.requestP95))
-                .averageNetworkRead(avgLong(results, x -> x.averageNetworkRead))
-                .averageNetworkWrite(avgLong(results, x -> x.averageNetworkWrite))
-                .peakThreadCount(avgLong(results, x -> x.peakThreadCount))
-                .averageJvmUserCpu(avgFloat(results, x -> x.maxJvmUserCpu))
-                .maxJvmUserCpu(avgFloat(results, x -> x.maxJvmUserCpu))
-                .averageJvmSystemCpu(avgFloat(results, x -> x.averageJvmSystemCpu))
-                .maxJvmSystemCpu(avgFloat(results, x -> x.maxJvmSystemCpu))
-                .averageMachineCpuTotal(avgFloat(results, x -> x.averageMachineCpuTotal))
-                .runDurationMs(avgLong(results, x -> x.runDurationMs))
-                .totalGcPauseNanos(avgLong(results, x -> x.totalGcPauseNanos))
-                .throughputRequestsPerSecond(avgDouble(results, x -> x.throughputRequestsPerSecond))
-                .build();
+    double networkWriteAvgMbps(String agentName){
+        return avgDouble(agentName, x -> (double)x.averageNetworkWrite) / (1024*1024);
     }
 
-    private float avgFloat(List<AppPerfResults> results, Function<AppPerfResults,Float> fn){
-        float sum = results.stream().reduce(0.0f, (acc, cur) -> acc + fn.apply(cur), Float::sum);
-        return sum/results.size();
+    double requestLatency(String agentName){
+        return avgDouble(agentName, x -> x.requestAvg);
     }
 
-    private double avgDouble(List<AppPerfResults> results, Function<AppPerfResults,Double> fn){
-        double sum = results.stream().reduce(0.0, (acc, cur) -> acc + fn.apply(cur), Double::sum);
-        return sum/results.size();
+    double throughput(String agentName) {
+        return avgDouble(agentName, x -> x.throughputRequestsPerSecond);
     }
 
-    private long avgLong(List<AppPerfResults> results, Function<AppPerfResults,Long> fn){
-        long sum = results.stream().reduce(0L, (acc, cur) -> acc + fn.apply(cur), Long::sum);
-        return sum/results.size();
+    double startupTime(String agentName) {
+        return avgDouble(agentName, x -> (double)x.startupDurationMs) / 1000.0;
+    }
+
+    private double avgDouble(String agentName, Function<AppPerfResults,Double> fn) {
+        long count = agentResults(agentName).count();
+        double sum = agentResults(agentName)
+                .reduce(0.0, (acc, cur) -> acc + fn.apply(cur), Double::sum);
+        return sum/count;
+    }
+
+    private Stream<AppPerfResults> agentResults(String agentName){
+        return rawResults.stream().filter(isAgent(agentName));
+    }
+
+    private Predicate<AppPerfResults> isAgent(String agentName) {
+        return r -> r.getAgentName().equals(agentName);
     }
 }

--- a/src/test/java/io/opentelemetry/results/ResultsAverager.java
+++ b/src/test/java/io/opentelemetry/results/ResultsAverager.java
@@ -33,10 +33,10 @@ public class ResultsAverager {
         return avgDouble(agentName, x -> (double)x.startupDurationMs) / 1000.0;
     }
 
-    private double avgDouble(String agentName, Function<AppPerfResults,Double> fn) {
+    private double avgDouble(String agentName, Function<AppPerfResults,Double> toDoubleFunction) {
         long count = agentResults(agentName).count();
         double sum = agentResults(agentName)
-                .reduce(0.0, (acc, cur) -> acc + fn.apply(cur), Double::sum);
+                .reduce(0.0, (acc, cur) -> acc + toDoubleFunction.apply(cur), Double::sum);
         return sum/count;
     }
 

--- a/src/test/java/io/opentelemetry/results/YamlSummaryPersister.java
+++ b/src/test/java/io/opentelemetry/results/YamlSummaryPersister.java
@@ -1,0 +1,98 @@
+package io.opentelemetry.results;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class YamlSummaryPersister implements ResultsPersister {
+
+    private final Path outfile;
+    private final Date date;
+
+    public YamlSummaryPersister(Path outfile) {
+        this(outfile, new Date());
+    }
+
+    public YamlSummaryPersister(Path outfile, Date date) {
+        this.outfile = outfile;
+        this.date = date;
+    }
+
+    @Override
+    public void write(List<AppPerfResults> results) {
+        try {
+            Map<String, Object> data = buildDataModel(results);
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+            mapper.writeValue(outfile.toFile(), data);
+        } catch (Exception e) {
+            System.out.println("Error writing yaml summary file");
+            e.printStackTrace();
+        }
+    }
+
+    private Map<String, Object> buildDataModel(List<AppPerfResults> results) throws IOException {
+        ResultsAverager averager = new ResultsAverager(results);
+        Map<String, Object> result = new HashMap<>();
+        String none = "No Instrumentation";
+        String agent = "Splunk OpenTelemetry Java agent";
+        String profiler = "Splunk OpenTelemetry Java agent with AlwaysOn Profiling";
+
+        result.put("version", guessVersion(results));
+        result.put("datetime", new SimpleDateFormat("MMMM d, yyyy").format(date));
+
+        Map<String, String> cpu = new HashMap<>();
+        cpu.put(none, String.format("%d%%", (int) (100 * averager.jvmUserCpu("none"))));
+        cpu.put(agent, String.format("%d%%", (int) (100 * averager.jvmUserCpu("splunk-otel"))));
+        cpu.put(profiler, String.format("%d%%", (int) (100 * averager.jvmUserCpu("profiler"))));
+        result.put("CPU", cpu);
+
+        Map<String, String> network = new HashMap<>();
+        network.put(none, String.format("%.2f MiB/s", averager.networkWriteAvgMbps("none")));
+        network.put(agent, String.format("%.2f MiB/s", averager.networkWriteAvgMbps("splunk-otel")));
+        network.put(profiler, String.format("%.2f MiB/s", averager.networkWriteAvgMbps("profiler")));
+        result.put("Network", network);
+
+        Map<String, String> latency = new HashMap<>();
+        latency.put(none, String.format("%.2f milliseconds", averager.requestLatency("none")));
+        latency.put(agent, String.format("%.2f milliseconds", averager.requestLatency("splunk-otel")));
+        latency.put(profiler, String.format("%.2f milliseconds", averager.requestLatency("profiler")));
+        result.put("Request latency", latency);
+
+        Map<String, String> throughput = new HashMap<>();
+        throughput.put(none, String.format("%.2f requests per second", averager.throughput("none")));
+        throughput.put(agent, String.format("%.2f requests per second", averager.throughput("splunk-otel")));
+        throughput.put(profiler, String.format("%.2f requests per second", averager.throughput("profiler")));
+        result.put("Throughput", throughput);
+
+        Map<String, String> startup = new HashMap<>();
+        startup.put(none, String.format("%.2f seconds", averager.startupTime("none")));
+        startup.put(agent, String.format("%.2f seconds", averager.startupTime("splunk-otel")));
+        startup.put(profiler, String.format("%.2f seconds", averager.startupTime("profiler")));
+        result.put("Startup time", startup);
+
+        return result;
+    }
+
+    private String guessVersion(List<AppPerfResults> results) {
+        return results.stream()
+                .filter(r -> r.getAgentName().equals("splunk-otel"))
+                .findFirst()
+                .map(r -> r.agent.getDescription())
+                .map(d -> d.substring(d.lastIndexOf(" ")+1))
+                .orElse("unknown version");
+    }
+
+    public static void main(String[] args) throws Exception {
+        List<AppPerfResults> rawRuns = CsvToResults.read("/tmp/results.csv");
+        new YamlSummaryPersister(Path.of("out.yaml")).write(rawRuns);
+    }
+
+}


### PR DESCRIPTION
Every run will now generate a yaml file that contains the averaged summary data required to template the docs, [for example these here](https://docs.splunk.com/Observability/gdi/get-data-in/application/java/performance.html#nav-Performance-overhead).

We also copy this summary up to the main results dir and call it `latest.yaml` so that there will always be a known path to the latest.

The doc will look like this:
```
---
Startup time:
  No Instrumentation: "15.23 seconds"
  Splunk OpenTelemetry Java agent: "22.14 seconds"
  Splunk OpenTelemetry Java agent with AlwaysOn Profiling: "22.92 seconds"
datetime: "March 21, 2022"
Request latency:
  No Instrumentation: "12.24 milliseconds"
  Splunk OpenTelemetry Java agent: "21.65 milliseconds"
  Splunk OpenTelemetry Java agent with AlwaysOn Profiling: "34.12 milliseconds"
Network:
  No Instrumentation: "12.57 MiB/s"
  Splunk OpenTelemetry Java agent: "49.95 MiB/s"
  Splunk OpenTelemetry Java agent with AlwaysOn Profiling: "51.03 MiB/s"
CPU:
  No Instrumentation: "32%"
  Splunk OpenTelemetry Java agent: "39%"
  Splunk OpenTelemetry Java agent with AlwaysOn Profiling: "45%"
Throughput:
  No Instrumentation: "890.47 requests per second"
  Splunk OpenTelemetry Java agent: "866.74 requests per second"
  Splunk OpenTelemetry Java agent with AlwaysOn Profiling: "797.46 requests per second"
version: "1.9.0"

```