### PR TITLE
Run overhead tests automatically based on the commit message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,10 @@ stages:
 
 run-test:
   stage: run-test
-  when: manual
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "main" && $CI_COMMIT_MESSAGE =~ /\[agent-version-update\]/'
+    - if: '$CI_COMMIT_REF_NAME == "main"'
+      when: manual
   image:
     name: docker.repo.splunkdev.net/ci-cd/ci-container:python-3.9-aws
   before_script:


### PR DESCRIPTION
The only sensible way of automating this seems to be through commit messages (it's surprisingly hard to create a tag on main once a given PR is merged), so I added a `[agent-version-update]` "tag" that'll trigger the overhead test run.

Related to https://github.com/signalfx/splunk-otel-java/pull/755