### PR TITLE
Add ability to link directly to a given result

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,7 @@
     <script src="data-client.js"></script>
     <script src="data-util.js"></script>
     <script src="overhead.js"></script>
+    <script src="urls.js"></script>
 </head>
 <body>
 <header class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-3 shadow">

--- a/web/overhead.js
+++ b/web/overhead.js
@@ -7,8 +7,14 @@ async function startOverhead() {
         .then(runNames => {
             console.log(runNames);
             populateRunsDropDown(runNames);
-            document.getElementById('test-run').value = runNames[0];
-            testRunChosen(runNames[0]);
+
+            const urlResultId = getResultIdFromUrl();
+            let selectedResult = runNames[0];
+            if(urlResultId && runNames.includes(urlResultId)){
+                selectedResult = urlResultId;
+            }
+            document.getElementById('test-run').value = selectedResult;
+            testRunChosen();
         });
 }
 
@@ -20,6 +26,7 @@ async function testRunChosen() {
     const results = await getResults(value)
     addOverview(config);
     addCharts(results, config);
+    updateUrl(value);
 }
 
 function addOverview(config) {

--- a/web/urls.js
+++ b/web/urls.js
@@ -1,0 +1,13 @@
+// Tools for helping manage urls (for permalinking)
+
+function getResultIdFromUrl(){
+    const url = new URL(window.location.href);
+    return url.searchParams.get('r');
+}
+
+function updateUrl(resultId){
+    const currentUrl = new URL(window.location.href);
+    currentUrl.searchParams.set("r", resultId);
+    history.replaceState({}, '', currentUrl.toString());
+}
+


### PR DESCRIPTION
When the result id is selected, it is now added to the url as a query parameter. When the page is first rendered, it also pulls that value out of the url and pre-selects the given result. This allows more direct linking to a given result set and section.