### PR TITLE
Prevent crash on missing config

### DIFF
--- a/web/overhead.js
+++ b/web/overhead.js
@@ -133,7 +133,8 @@ function addCharts(aggregated, config) {
 
 function makeMarketingNames(agentNames, config) {
     return agentNames.map(agentName => {
-        const agent = config.agents.find( agent => agent.name === agentName);
+        const agents = config.agents || [];
+        const agent = agents.find( agent => agent.name === agentName);
         return agent ? agent.description : agentName;
     })
 }


### PR DESCRIPTION
Some of the historical runs didn't yet include the `config.json` file, so we have to guard against that.