### PR TITLE
Don't include the latest.yaml file in the index list

### DIFF
--- a/provision/create-results-pr.sh
+++ b/provision/create-results-pr.sh
@@ -43,7 +43,7 @@ MSG="Add test results: ${REV}"
 rsync -avv --progress "${RESULTS}/${REV}" github-clone/results/
 cd github-clone
 echo "Results list: " && ls -l results/
-ls -1 results/ | grep -v README | grep -v index.txt > results/index.txt
+ls -1 results/ | grep -v README | grep -v index.txt | grep -v latest.yaml > results/index.txt
 echo "Copying latest yaml..."
 cp results/${REV}/results.yaml results/latest.yaml
 echo "Adding new files to changelist"

--- a/web/data-client.js
+++ b/web/data-client.js
@@ -3,7 +3,10 @@
 async function getRuns(){
     return fetch(`results/index.txt`)
         .then(resp => resp.text())
-        .then(body => body.split("\n").filter(x => x !== 'index.txt'));
+        .then(body =>
+            body.split("\n")
+                .filter(x => x.match(/^\d{8}_/))
+        );
 }
 
 async function getResults(name){


### PR DESCRIPTION
Right now the dropdown includes the spurious yaml file:
<img width="673" alt="image" src="https://user-images.githubusercontent.com/75337021/175612182-4c21630f-4222-4500-a15a-3de4cd35ab51.png">
Let's omit it from `index.txt` and include a stricter filter after we fetch.