### PR TITLE
Add a historic view

### DIFF
--- a/web/historical.js
+++ b/web/historical.js
@@ -35,6 +35,20 @@ function addHistoricalOverview(configsWithResults) {
 function addHistoricalCharts(configsWithResults) {
     makeHistoricalChart(configsWithResults, 'startupDurationMs', "Seconds", x => x / 1000);
     makeHistoricalChart(configsWithResults, 'averageCpuUser', "% CPU load");
+    makeHistoricalChart(configsWithResults, 'maxCpuUser', "% CPU load");
+    makeHistoricalChart(configsWithResults, 'maxHeapUsed', "Megabytes", x => x / (1024 * 1024));
+    makeHistoricalChart(configsWithResults, 'totalAllocatedMB', "Gigabytes", x => x / (1024));
+    makeHistoricalChart(configsWithResults, 'totalGCTime', "Seconds", x => x / (1000 * 1000 * 1000));
+    makeHistoricalChart(configsWithResults, 'gcPauseMs', "Milliseconds");
+    makeHistoricalChart(configsWithResults, 'iterationAvg', "Milliseconds");
+    makeHistoricalChart(configsWithResults, 'iterationP95', "Milliseconds");
+    makeHistoricalChart(configsWithResults, 'requestAvg', "Milliseconds");
+    makeHistoricalChart(configsWithResults, 'requestP95', "Milliseconds");
+    makeHistoricalChart(configsWithResults, 'netReadAvg', "MiB/s", x => x / (1024 * 1024));
+    makeHistoricalChart(configsWithResults, 'netWriteAvg', "MiB/s", x => x / (1024 * 1024));
+    makeHistoricalChart(configsWithResults, 'peakThreadCount', "MiB/s");
+    makeHistoricalChart(configsWithResults, 'maxThreadContextSwitchRate', "Switches per second");
+    makeHistoricalChart(configsWithResults, 'runDurationMs', "Seconds", x => x / 1000);
 
 }
 

--- a/web/historical.js
+++ b/web/historical.js
@@ -74,6 +74,9 @@ function makeHistoricalChart(configsWithResults, resultsType, axisTitle, scaleFu
             right: 40,
             top: 40
         },
+        axisY: {
+            low: 0
+        },
         lineSmooth: Chartist.Interpolation.none({
             fillHoles: false
         }),

--- a/web/historical.js
+++ b/web/historical.js
@@ -20,8 +20,8 @@ async function showHistorical() {
     configs.sort((a, b) => a.run.localeCompare(b.run));
     // console.log(configs);
     const configsWithResults = await addResults(configs);
-    console.log('everything:');
-    console.log(configsWithResults);
+    // console.log('everything:');
+    // console.log(configsWithResults);
     addHistoricalOverview(configsWithResults);
     addHistoricalCharts(configsWithResults);
     setTimeout(tiltLabels, 1);
@@ -60,7 +60,10 @@ function makeHistoricalChart(configsWithResults, resultsType, axisTitle, scaleFu
 
     const labels = results.map(x => x[0]);
     const seriesData = data.map(x => ({"name": x[0], "data": x[1]}));
-    console.log(seriesData);
+    // console.log(seriesData);
+    seriesData.forEach(series => {
+        series.data = series.data.map(scaleFunction);
+    });
     new Chartist.Line(`#${resultsType}-chart`, {
         labels: labels,
         series: seriesData

--- a/web/historical.js
+++ b/web/historical.js
@@ -18,10 +18,7 @@ async function toggleHistorical() {
 async function showHistorical() {
     const configs = await getAllRunConfigs();
     configs.sort((a, b) => a.run.localeCompare(b.run));
-    // console.log(configs);
     const configsWithResults = await addResults(configs);
-    // console.log('everything:');
-    // console.log(configsWithResults);
     addHistoricalOverview(configsWithResults);
     addHistoricalCharts(configsWithResults);
     setTimeout(tiltLabels, 1);
@@ -58,23 +55,18 @@ function makeHistoricalChart(configsWithResults, resultsType, axisTitle, scaleFu
         const res = config.results.results[resultsType];
         return [config.run, res];
     });
-    // console.log(results);
     const agents = allAgents(configsWithResults);
     const standardAgents = agents.filter(agent => !agent.includes(':'));
-    // console.log(agents);
     const groupedByAgent = standardAgents.map(agent => {
         return [agent, results.map(result => {
            return result[1][agent];
         })];
     });
 
-    // console.log(groupedByAgent);
     const data = groupedByAgent.filter(seriesIsEmpty);
-    // console.log(data);
 
     const labels = results.map(x => x[0]);
     const seriesData = data.map(x => ({"name": x[0], "data": x[1]}));
-    // console.log(seriesData);
     seriesData.forEach(series => {
         series.data = series.data.map(scaleFunction);
     });

--- a/web/historical.js
+++ b/web/historical.js
@@ -1,16 +1,23 @@
 async function toggleHistorical() {
     console.log("Toggle historical view...")
-    const sel = document.getElementById('test-run');
-    //currentUrl.searchParams.delete(name);
+    const testDropDown = document.getElementById('test-run');
+    // currentUrl.searchParams.delete(name);
     // sel.disabled = !sel.disabled;
-    if (sel.classList.contains('d-none')) {
-        sel.classList.remove('d-none');
+    let historicalCurrentlyShown = testDropDown.classList.contains('d-none');
+    if (historicalCurrentlyShown) {
+        testDropDown.classList.remove('d-none');
+        await testRunChosen();
+        document.querySelectorAll('.ct-legend').forEach(x => x.style.display = 'none');
     } else {
-        sel.classList.add('d-none');
+        testDropDown.classList.add('d-none');
+        updateUrlForHistorical();
+        await showHistorical();
     }
+}
 
+async function showHistorical() {
     const configs = await getAllRunConfigs();
-    configs.sort((a,b) => a.run.localeCompare(b.run));
+    configs.sort((a, b) => a.run.localeCompare(b.run));
     // console.log(configs);
     const configsWithResults = await addResults(configs);
     console.log('everything:');
@@ -60,7 +67,9 @@ function makeHistoricalChart(configsWithResults, resultsType, axisTitle, scaleFu
     }, {
         fullWidth: true,
         chartPadding: {
-            right: 40
+            left: 40,
+            right: 40,
+            top: 40
         },
         lineSmooth: Chartist.Interpolation.none({
             fillHoles: false

--- a/web/historical.js
+++ b/web/historical.js
@@ -1,0 +1,112 @@
+async function toggleHistorical() {
+    console.log("Toggle historical view...")
+    const sel = document.getElementById('test-run');
+    //currentUrl.searchParams.delete(name);
+    // sel.disabled = !sel.disabled;
+    if (sel.classList.contains('d-none')) {
+        sel.classList.remove('d-none');
+    } else {
+        sel.classList.add('d-none');
+    }
+
+    const configs = await getAllRunConfigs();
+    configs.sort((a,b) => a.run.localeCompare(b.run));
+    // console.log(configs);
+    const configsWithResults = await addResults(configs);
+    console.log('everything:');
+    console.log(configsWithResults);
+    addHistoricalOverview(configsWithResults);
+    addHistoricalCharts(configsWithResults);
+    setTimeout(tiltLabels, 1);
+}
+
+function addHistoricalOverview(configsWithResults) {
+    const overview = document.getElementById('overview');
+    overview.innerHTML = 'Showing historical comparison view';
+}
+
+function addHistoricalCharts(configsWithResults) {
+    makeHistoricalChart(configsWithResults, 'startupDurationMs', "Seconds", x => x / 1000);
+    makeHistoricalChart(configsWithResults, 'averageCpuUser', "% CPU load");
+
+}
+
+function makeHistoricalChart(configsWithResults, resultsType, axisTitle, scaleFunction = x => x) {
+
+    const results = configsWithResults.map(config => {
+        const res = config.results.results[resultsType];
+        return [config.run, res];
+    });
+    // console.log(results);
+    const agents = allAgents(configsWithResults);
+    const standardAgents = agents.filter(agent => !agent.includes(':'));
+    // console.log(agents);
+    const groupedByAgent = standardAgents.map(agent => {
+        return [agent, results.map(result => {
+           return result[1][agent];
+        })];
+    });
+
+    // console.log(groupedByAgent);
+    const data = groupedByAgent.filter(seriesIsEmpty);
+    // console.log(data);
+
+    const labels = results.map(x => x[0]);
+    const seriesData = data.map(x => ({"name": x[0], "data": x[1]}));
+    console.log(seriesData);
+    new Chartist.Line(`#${resultsType}-chart`, {
+        labels: labels,
+        series: seriesData
+    }, {
+        fullWidth: true,
+        chartPadding: {
+            right: 40
+        },
+        lineSmooth: Chartist.Interpolation.none({
+            fillHoles: false
+        }),
+        plugins: [
+            makeChartistAxisTitle(axisTitle),
+            Chartist.plugins.legend({
+                // position: 'bottom' doesn't work meh
+            })
+        ]
+    });
+}
+
+function seriesIsEmpty(pair){
+    const series = pair[1];
+    return series.filter(x => x !== undefined).length > 0;
+}
+
+function allAgents(configsWithResults){
+    const result = new Set();
+    configsWithResults.forEach(config => {
+       (config.agents || []).forEach( agent => result.add(agent.name));
+       config.results.agents.forEach(agent => result.add(agent));
+    });
+    return [...result];
+}
+
+async function getAllRunConfigs(){
+    const runs = await getRuns();
+    const runPromises = runs.map(
+        run => getConfig(run)
+            .then(config => {
+                config['run'] = run;
+                return config;
+            })
+    );
+    return Promise.all(runPromises);
+}
+
+async function addResults(configs) {
+    const resultsPromises = configs.map(config => {
+       return getResults(config.run)
+           .then(results => {
+               config['results'] = results;
+               return config;
+           });
+    });
+    return Promise.all(resultsPromises);
+}

--- a/web/index.html
+++ b/web/index.html
@@ -10,21 +10,26 @@
     <script src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/chartist-plugin-axistitle@0.0.7/dist/chartist-plugin-axistitle.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/chartist-plugin-barlabels@0.0.5/dist/chartist-plugin-barlabels.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chartist-plugin-legend/0.6.2/chartist-plugin-legend.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="overhead.css">
     <script src="data-client.js"></script>
     <script src="data-util.js"></script>
     <script src="overhead.js"></script>
     <script src="urls.js"></script>
+    <script src="historical.js"></script>
 </head>
 <body>
 <header class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-3 shadow">
     <div class="container-fluid">
         <div class="row">
             <div class="col">
-                <select id='test-run' class="form-select" aria-label="history of test runs">
+                <select id='test-run' class="form-select form-select-sm" aria-label="history of test runs" style="width:auto">
                     <option selected>Select a test run</option>
                 </select>
+            </div>
+            <div class="col">
+                <a title="Toggle historical view" class="navbar-brand" href="#" onclick="toggleHistorical()"><i class="bi bi-graph-up text-white"></i></a>
             </div>
             <div class="col">
                 <a class="navbar-brand col-md-3 col-lg-2 me-0 px-3 fs-3" href="#">OpenTelemetry Java Agent Overhead</a>

--- a/web/overhead.css
+++ b/web/overhead.css
@@ -53,19 +53,6 @@ h2:before {
     stroke-width: 4px;
 }
 
-/* -- rotate the label text -- */
-/*svg.ct-chart-bar, svg.ct-chart-line{*/
-/*    overflow: visible;*/
-/*}*/
-/*.ct-label.ct-label.ct-horizontal.ct-end {*/
-/*    position: relative;*/
-/*    justify-content: flex-end;*/
-/*    text-align: right;*/
-/*    transform-origin: 100% 0;*/
-/*    transform: translate(-100%) rotate(-55deg);*/
-/*    white-space:nowrap;*/
-/*}*/
-
 /* ---- ct-legend for chartist -- */
 
 .ct-legend li {

--- a/web/overhead.css
+++ b/web/overhead.css
@@ -53,6 +53,13 @@ h2:before {
     stroke-width: 4px;
 }
 
+.ct-series-a .ct-line {
+    stroke: #3760e3;
+}
+.ct-series-a .ct-point {
+    stroke: #3760e3;
+}
+
 /* ---- ct-legend for chartist -- */
 
 .ct-legend {
@@ -89,8 +96,8 @@ h2:before {
     margin: 0;
 }
 .ct-legend .ct-series-0:before {
-    background-color: #d70206;
-    border-color: #d70206;
+    background-color: #3760e3;
+    border-color: #3760e3;
 }
 .ct-legend .ct-series-1:before {
     background-color: #f05b4f;
@@ -110,8 +117,8 @@ h2:before {
 }
 
 .ct-chart-line-multipleseries .ct-legend .ct-series-0:before {
-    background-color: #d70206;
-    border-color: #d70206;
+    background-color: #3760e3;
+    border-color: #3760e3;
 }
 
 .ct-chart-line-multipleseries .ct-legend .ct-series-1:before {

--- a/web/overhead.css
+++ b/web/overhead.css
@@ -55,6 +55,9 @@ h2:before {
 
 /* ---- ct-legend for chartist -- */
 
+.ct-legend {
+    padding-left: 100px;
+}
 .ct-legend li {
     position: relative;
     padding-left: 23px;

--- a/web/overhead.css
+++ b/web/overhead.css
@@ -44,3 +44,91 @@ h2:before {
 .ct-bar-label {
     text-color: black;
 }
+
+.ct-line {
+    stroke-width: 2px;
+}
+
+.ct-point {
+    stroke-width: 4px;
+}
+
+/* -- rotate the label text -- */
+/*svg.ct-chart-bar, svg.ct-chart-line{*/
+/*    overflow: visible;*/
+/*}*/
+/*.ct-label.ct-label.ct-horizontal.ct-end {*/
+/*    position: relative;*/
+/*    justify-content: flex-end;*/
+/*    text-align: right;*/
+/*    transform-origin: 100% 0;*/
+/*    transform: translate(-100%) rotate(-55deg);*/
+/*    white-space:nowrap;*/
+/*}*/
+
+/* ---- ct-legend for chartist -- */
+
+.ct-legend li {
+    position: relative;
+    padding-left: 23px;
+    margin-right: 10px;
+    margin-bottom: 3px;
+    cursor: pointer;
+    display: inline-block;
+}
+.ct-legend li:before {
+    width: 12px;
+    height: 12px;
+    position: absolute;
+    left: 0;
+    content: '';
+    border: 3px solid transparent;
+    border-radius: 2px;
+}
+.ct-legend li.inactive:before {
+    background: transparent;
+}
+.ct-legend.ct-legend-inside {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.ct-legend.ct-legend-inside li{
+    display: block;
+    margin: 0;
+}
+.ct-legend .ct-series-0:before {
+    background-color: #d70206;
+    border-color: #d70206;
+}
+.ct-legend .ct-series-1:before {
+    background-color: #f05b4f;
+    border-color: #f05b4f;
+}
+.ct-legend .ct-series-2:before {
+    background-color: #f4c63d;
+    border-color: #f4c63d;
+}
+.ct-legend .ct-series-3:before {
+    background-color: #d17905;
+    border-color: #d17905;
+}
+.ct-legend .ct-series-4:before {
+    background-color: #453d3f;
+    border-color: #453d3f;
+}
+
+.ct-chart-line-multipleseries .ct-legend .ct-series-0:before {
+    background-color: #d70206;
+    border-color: #d70206;
+}
+
+.ct-chart-line-multipleseries .ct-legend .ct-series-1:before {
+    background-color: #f4c63d;
+    border-color: #f4c63d;
+}
+
+.ct-chart-line-multipleseries .ct-legend li.inactive:before {
+    background: transparent;
+}

--- a/web/overhead.js
+++ b/web/overhead.js
@@ -9,11 +9,14 @@ async function startOverhead() {
             populateRunsDropDown(runNames);
 
             const urlResultId = getResultIdFromUrl();
-            let selectedResult = runNames[0];
+            let selectedResult = runNames[runNames.length - 1];
             if(urlResultId && runNames.includes(urlResultId)){
                 selectedResult = urlResultId;
             }
             document.getElementById('test-run').value = selectedResult;
+            if(urlIsShowingHistorical()){
+                return toggleHistorical();
+            }
             testRunChosen();
         });
 }

--- a/web/overhead.js
+++ b/web/overhead.js
@@ -164,18 +164,50 @@ function makeChart(aggregated, config, resultType, axisTitle, scaleFunction = x 
                         return text.toFixed(2);
                     }
                 }),
-                Chartist.plugins.ctAxisTitle({
-                    axisY: {
-                        axisTitle: axisTitle,
-                        axisClass: "ct-axis-title",
-                        offset: {
-                            x: 0,
-                            y: 15
-                        },
-                        flipTitle: true
-                    }
-                })
+                makeChartistAxisTitle(axisTitle)
             ]
         },
     );
+}
+
+function makeChartistAxisTitle(axisTitle) {
+    return Chartist.plugins.ctAxisTitle({
+        axisY: {
+            axisTitle: axisTitle,
+            axisClass: "ct-axis-title",
+            offset: {
+                x: 0,
+                y: 15
+            },
+            flipTitle: true
+        }
+    });
+}
+
+function tiltLabels(){
+    document.querySelectorAll('svg.ct-chart-bar, svg.ct-chart-line').forEach(x => {
+        x.style.overflow = 'visible';
+    })
+    const labels = document.querySelectorAll('.ct-label.ct-label.ct-horizontal.ct-end');
+    labels.forEach(label => {
+        label.style.position = 'relative';
+        label.style['justify-content'] = 'flex-end';
+        label.style['text-align'] = 'right';
+        label.style['transform-origin'] = '100% 0';
+        label.style.transform = 'translate(-100%) rotate(-55deg)';
+        label.style['white-space'] = 'nowrap';
+        label.style['font-size'] = '0.6em';
+    });
+}
+
+function straightLabels(){
+    const labels = document.querySelectorAll('.ct-label.ct-label.ct-horizontal.ct-end');
+    labels.forEach(label => {
+        label.style.removeProperty('position');
+        label.style.removeProperty('justify-content');
+        label.style.removeProperty('text-align');
+        label.style.removeProperty('transform-origin');
+        label.style.removeProperty('transform');
+        label.style.removeProperty('white-space');
+    });
 }

--- a/web/urls.js
+++ b/web/urls.js
@@ -11,3 +11,13 @@ function updateUrl(resultId){
     history.replaceState({}, '', currentUrl.toString());
 }
 
+function updateUrlForHistorical(){
+    const url = new URL(window.location.href);
+    url.searchParams.set('r', 'historical');
+    history.replaceState({}, '', url.toString());
+}
+
+function urlIsShowingHistorical(){
+    const url = new URL(window.location.href);
+    return 'historical' === url.searchParams.get('r');
+}


### PR DESCRIPTION
In order to spot trends or to more easily perform comparisons between runs, want to have a historic view.
This change adds a button next to the run picker:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/75337021/178050808-1a3f2f5f-b7ad-4a2e-8533-9f59f35b7c76.png">
Clicking on the chart button toggles historic mode on/off. When historic mode is enabled, the picker is hidden and the graphs then look something like this:

<img width="954" alt="image" src="https://user-images.githubusercontent.com/75337021/178050962-457eb447-3979-480a-b5a6-59af3f4250c1.png">

