### PR TITLE
Configure git before commit

### DIFF
--- a/.github/workflows/web-to-gh-pages.yaml
+++ b/.github/workflows/web-to-gh-pages.yaml
@@ -28,6 +28,10 @@ jobs:
           for f in $(find . -type f -depth 1 -not -path '*/.*') ; do
           git add "$f" 
           done
+      - name: Configure git user info
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
       - name: Commit and push changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action failed due to missing git user info: https://github.com/signalfx/splunk-otel-java-overhead-test/runs/7286600189

This adds it.